### PR TITLE
Fixed UnicodeEncodeError ( http://agiliq.com/blog/2014/12/understandi…

### DIFF
--- a/gicowa/impl/output.py
+++ b/gicowa/impl/output.py
@@ -40,5 +40,5 @@ class Output:
         given color.
         Returns 'text' with no color if not self.colored.
         """
-        text = str(text)
+        text = unicode(text)
         return text if not self.colored else "\033[" + str(color) + "m" + text + "\033[0m"


### PR DESCRIPTION
…ng-python-unicode-str-unicodeencodeerro/ )

The UnicodeEncodeError exception was raised for example while listing the last commit from amule-project/amule, due to the developer's name (Dévai Tamás) containing Unicode characters (see http://agiliq.com/blog/2014/12/understanding-python-unicode-str-unicodeencodeerro/ ).
